### PR TITLE
Update style for iOS look

### DIFF
--- a/css/styless.css
+++ b/css/styless.css
@@ -1,8 +1,9 @@
 /* General Styles */
 body {
-  font-family: 'Arial', sans-serif;
-  background-color: #121212;
-  color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro", "Helvetica Neue",
+    Helvetica, Arial, sans-serif;
+  background-color: #f2f2f7;
+  color: #1c1c1e;
 }
 
 .navbar-brand img {
@@ -27,12 +28,13 @@ body {
   text-align: center;
   margin-bottom: 40px;
   font-size: 2rem;
-  color: #ffcc00;
+  color: #007aff;
   text-transform: uppercase;
 }
 
 .footer {
-  background-color: #333;
+  background-color: #f2f2f7;
+  color: #6e6e73;
   padding: 20px 0;
   text-align: center;
 }
@@ -45,12 +47,12 @@ body {
 }
 
 .social-icons a:hover {
-  color: #ffcc00;
+  color: #007aff;
 }
 
 /* Skills Section */
 #skills {
-  background-color: #000;
+  background-color: #f2f2f7;
 }
 
 .skills-grid {
@@ -60,13 +62,13 @@ body {
 }
 
 .skill-card {
-  background-color: #1e1e1e;
-  border-radius: 10px;
+  background-color: #ffffff;
+  border-radius: 12px;
   padding: 20px;
   text-align: center;
   width: 120px;
   margin: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
   transition: transform 0.3s, box-shadow 0.3s;
 }
 
@@ -88,30 +90,31 @@ body {
 
 /* Button Styles */
 .btn-primary {
-  background-color: #ffcc00;
+  background-color: #007aff;
   border: none;
+  border-radius: 10px;
   transition: background-color 0.3s, transform 0.3s;
 }
 
 .btn-primary:hover {
-  background-color: #ffaa00;
+  background-color: #0051a8;
   transform: translateY(-2px);
 }
 
 /* Card Styles */
 .card {
-  background-color: #1e1e1e;
+  background-color: #ffffff;
   border: none;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
   margin-bottom: 34px;
 }
 
 .card-body {
-  color: #ffffff;
+  color: #1c1c1e;
 }
 
 .card-title {
-  color: #ffcc00;
+  color: #007aff;
 }
 
 .card img {
@@ -134,19 +137,20 @@ body {
 }
 
 .card .btn-primary {
-  background-color: #ffcc00;
+  background-color: #007aff;
   border: none;
-  margin-top: 17px
+  border-radius: 10px;
+  margin-top: 17px;
 }
 
 .card .btn-primary:hover {
-  background-color: #ffaa00;
+  background-color: #0051a8;
 }
 
 /* Timeline Styles */
 .main-timeline {
   position: relative;
-  background-color: #000; 
+  background-color: #f2f2f7;
 }
 
 .main-timeline::after {
@@ -253,18 +257,18 @@ body {
 }
 
 .nav-tabs .nav-link.active {
-  background-color: #ffcc00;
-  color: #000;
+  background-color: #007aff;
+  color: #fff;
 }
 
 .nav-tabs .nav-link {
-  color: #fff;
-  background-color: #333;
-  border: 1px solid #444;
+  color: #007aff;
+  background-color: #fff;
+  border: 1px solid #ccc;
 }
 
 .nav-tabs .nav-link:hover {
-  background-color: #ffaa00;
+  background-color: #0051a8;
   color: #fff;
 }
 
@@ -274,11 +278,21 @@ body {
 
 /* Navbar Scroll Effect */
 .navbar {
+    background-color: #ffffff !important;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
     transition: background-color 0.5s ease;
 }
 
+.navbar .nav-link {
+    color: #007aff !important;
+}
+
+.navbar .nav-link:hover {
+    color: #0051a8 !important;
+}
+
 .navbar.scrolled {
-    background-color: rgba(0, 0, 0, 0.9) !important;
+    background-color: #f9f9f9 !important;
 }
 
 /* Parallax Section */


### PR DESCRIPTION
## Summary
- use SF Pro font stack and lighter base colors
- adopt blue accent across buttons and headings
- restyle nav tabs and navbar to match iOS
- update card and skill styles for lighter palette

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850814849d8832690005a743880d1a5